### PR TITLE
replace triple backticks (```) to single backticks (`)

### DIFF
--- a/code_documenter.py
+++ b/code_documenter.py
@@ -1391,15 +1391,15 @@ class Procedure():
         # proc_name:str, line_no:str, line_text:str
     
 
-        # replacer_placeholder_reference = "\n" * 3 + f"- [```{target_procedure_name}```](#{target_procedure_name}) <small> : [Zeile {line_no_reference}] : ```{line_code}``` </small>".replace(line_code, line_code.rstrip("\n")) + "\n"
+        # replacer_placeholder_reference = "\n" * 3 + f"- [`{target_procedure_name}`](#{target_procedure_name}) <small> : [Zeile {line_no_reference}] : `{line_code}` </small>".replace(line_code, line_code.rstrip("\n")) + "\n"
         
         if line_text == "":
             __optional_code_line = ""
         else:
-            __optional_code_line = f": ```{line_text}```"
+            __optional_code_line = f": `{line_text}`"
 
 
-        markdown_entry = f"- [```{proc_name}```](#{proc_name}) : <small>  [Zeile {line_no}] {__optional_code_line} </small>"
+        markdown_entry = f"- [`{proc_name}`](#{proc_name}) : <small>  [Zeile {line_no}] {__optional_code_line} </small>"
 
         markdown_entry = markdown_entry.replace(line_text, line_text.rstrip("\n")) 
         
@@ -1702,7 +1702,7 @@ class Procedure():
                 # OBSOLET: wird in Methode get_markdown_for_code_line_of_call_entry erledigt
                 # line_code:str = line_code.rstrip("\n")
 
-                # replacer_placeholder_reference = f"* [```{calling_procedure_name}```](#{calling_procedure_name}) : <small>  [Zeile {line_no}] : ```{line_code}``` </small>"
+                # replacer_placeholder_reference = f"* [`{calling_procedure_name}`](#{calling_procedure_name}) : <small>  [Zeile {line_no}] : `{line_code}` </small>"
 
 
                 replacer_placeholder_reference = self.get_markdown_for_code_line_of_call_entry(calling_procedure_name, line_no, line_code)
@@ -1710,7 +1710,7 @@ class Procedure():
 
 
                 # # AUSBLICK: weitere collapse details : funktioniert technisch, allerdings steht das collapsable immer in neuer Zeile und daher wird es groß - vielleicht später in schön machen...
-                # __replacer_placeholder_reference = f"*   [```{calling_procedure_name}```](#{calling_procedure_name})  <details> <summary>: <small>Zeile {line_no}</small> </summary> ```{line_code}``` </details>"
+                # __replacer_placeholder_reference = f"*   [`{calling_procedure_name}`](#{calling_procedure_name})  <details> <summary>: <small>Zeile {line_no}</small> </summary> `{line_code}` </details>"
 
 
 


### PR DESCRIPTION
Changed all instances of triple backticks to single backticks to address issues raised in issue #19 

Fixes #19